### PR TITLE
Add status dropdown rows for BFP and ACW

### DIFF
--- a/eloghaldia/src/app/components/allformats/boilerandbopcomponents/bop-logsheet/bop-logsheet.component.html
+++ b/eloghaldia/src/app/components/allformats/boilerandbopcomponents/bop-logsheet/bop-logsheet.component.html
@@ -26,6 +26,19 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td class="border p-2 text-center font-semibold">Status</td>
+        <td class="border p-1"></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp1a" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp1b" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp1c" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp2a" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp2b" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp2c" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp3a" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp3b" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="bfpStatus.bfp3c" placeholder="Select"></p-dropdown></td>
+      </tr>
       <tr *ngFor="let row of bfpUnit1and2Arr">
         <td class="border p-2">{{ row.parameter }}</td>
         <td class="border p-2 text-center">{{ row.unit }}</td>
@@ -59,6 +72,16 @@
       </tr>
     </thead>
     <tbody>
+      <tr>
+        <td class="border p-2 text-center font-semibold">Status</td>
+        <td class="border p-1"></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="acwStatus.acw1a" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="acwStatus.acw1b" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="acwStatus.acw2a" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="acwStatus.acw2b" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="acwStatus.acw3a" placeholder="Select"></p-dropdown></td>
+        <td class="border p-1"><p-dropdown [options]="pumpStatusOptions" [(ngModel)]="acwStatus.acw3b" placeholder="Select"></p-dropdown></td>
+      </tr>
       <tr *ngFor="let row of acwArr">
         <td class="border p-2">{{ row.parameter }}</td>
         <td class="border p-2">{{ row.unit }}</td>

--- a/eloghaldia/src/app/components/allformats/boilerandbopcomponents/bop-logsheet/bop-logsheet.component.ts
+++ b/eloghaldia/src/app/components/allformats/boilerandbopcomponents/bop-logsheet/bop-logsheet.component.ts
@@ -32,6 +32,8 @@ export class BopLogsheetComponent implements OnInit, OnChanges {
   hotwellPumpStatus: any = { hwp1: '', hwp2: '', hwp3: '', hwp4: '' };
   boilerFillPumpStatus: any = { p1: '', p2: '', p3: '', p4: '' };
   compressorStatus: any = { compA: '', compB: '', compC: '' };
+  bfpStatus: any = { bfp1a: '', bfp1b: '', bfp1c: '', bfp2a: '', bfp2b: '', bfp2c: '', bfp3a: '', bfp3b: '', bfp3c: '' };
+  acwStatus: any = { acw1a: '', acw1b: '', acw2a: '', acw2b: '', acw3a: '', acw3b: '' };
 
   pumpStatusOptions = [
     { label: 'Running', value: 'Running' },


### PR DESCRIPTION
## Summary
- add BFP and ACW status objects
- insert dropdown rows in BFP and ACW tables

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867751e73c48328bfa2870019890b77