### PR TITLE
Add BOP logsheet controller and endpoints

### DIFF
--- a/elogHaldia-backend/src/controllers/boplogsheet.controller.js
+++ b/elogHaldia-backend/src/controllers/boplogsheet.controller.js
@@ -1,0 +1,75 @@
+const { pool } = require("../utilities/dbconfig");
+const crypto = require("./crypto");
+
+/**
+ * Insert BOP logsheet data
+ */
+exports.insertBopLogsheet = async (req, res) => {
+  const client = await pool.connect();
+  try {
+    const decryptedBody = await crypto.decipher(req.body.encryptedbody);
+    const body = JSON.parse(decryptedBody);
+
+    const { shiftdate, shiftname, shiftdatestr, ...readings } = body;
+
+    const columns = [
+      'shiftdate',
+      'shiftname',
+      'shiftdatestr',
+      ...Object.keys(readings)
+    ];
+    const values = [
+      shiftdate,
+      shiftname,
+      shiftdatestr,
+      ...Object.values(readings)
+    ];
+    const placeholders = columns.map((_, i) => `$${i + 1}`);
+
+    const query = `
+      INSERT INTO bop_logsheet (${columns.join(', ')})
+      VALUES (${placeholders.join(', ')})
+    `;
+
+    await client.query(query, values);
+
+    res.json({ success: true, message: 'New BOP logsheet entry saved.' });
+  } catch (err) {
+    console.error('Insert BOP logsheet error:', err);
+    res.status(500).json({ success: false, message: 'Insert failed.' });
+  } finally {
+    client.release();
+  }
+};
+
+/**
+ * Get latest BOP logsheet data for a shift
+ */
+exports.getBopLogsheet = async (req, res) => {
+  const client = await pool.connect();
+  try {
+    const decryptedBody = await crypto.decipher(req.body.encryptedbody);
+    const body = JSON.parse(decryptedBody);
+    const { shiftdate, shiftname } = body;
+
+    const query = `
+      SELECT * FROM bop_logsheet
+      WHERE shiftdate = $1 AND shiftname = $2
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+
+    const result = await client.query(query, [shiftdate, shiftname]);
+
+    if (result.rows.length > 0) {
+      res.json({ success: true, data: result.rows[0] });
+    } else {
+      res.json({ success: false, message: 'No data found for this shift.' });
+    }
+  } catch (err) {
+    console.error('Fetch BOP logsheet error:', err);
+    res.status(500).json({ success: false, message: 'Fetch failed.' });
+  } finally {
+    client.release();
+  }
+};

--- a/elogHaldia-backend/src/routers/format.router.js
+++ b/elogHaldia-backend/src/routers/format.router.js
@@ -10,6 +10,7 @@ const formattsiunit3controller = require("../controllers/formattsiunit3.controll
 const formatlssuaeqpController = require("../controllers/formatlssuaeqp.controller");
 const formatisisController = require("../controllers/formatisis.controller");
 const formatboilerLogsheetController = require("../controllers/formatboiler-logsheet.controller");
+const bopLogsheetController = require("../controllers/boplogsheet.controller");
 const formatBoilerDamperStatusController = require("../controllers/boilerdamperstatus.controller");
 const formatBoilerHpdpAgitatorController = require("../controllers/boilerhpdpagitator.controller");
 const formatBoilerIdfanStatusController = require("../controllers/boileridfanstatus.controller"); // ✅ NEW
@@ -49,6 +50,10 @@ router.post("/getlsislanding", formatisisController.getIsisLanding);
 // Boiler logsheet
 router.post("/insertboilerandbop", formatboilerLogsheetController.insertBoilerAndBop);
 router.post("/getboilerandbop", formatboilerLogsheetController.getBoilerAndBop);
+
+// BOP Logsheet
+router.post("/insertboplogsheet", bopLogsheetController.insertBopLogsheet);
+router.post("/getboplogsheet", bopLogsheetController.getBopLogsheet);
 
 // Boiler Damper Status
 router.post("/insertboilerdamperstatus", formatBoilerDamperStatusController.insertboilerdamperstatus);

--- a/eloghaldia/src/app/services/utility-endpoints.service.ts
+++ b/eloghaldia/src/app/services/utility-endpoints.service.ts
@@ -44,6 +44,9 @@ export class UtilityEndpointsService {
     getboilerandbop: "format/getboilerandbop",
     insertboilerandbop: "format/insertboilerandbop",
 
+    getboplogsheet: "format/getboplogsheet",
+    insertboplogsheet: "format/insertboplogsheet",
+
     getboilerdamperstatus: "format/getboilerdamperstatus",
     insertboilerdamperstatus: "format/insertboilerdamperstatus",
 


### PR DESCRIPTION
## Summary
- create `boplogsheet.controller.js` for handling BOP logsheet data
- expose new insert and get routes in `format.router.js`
- update Angular endpoint service with new API paths

## Testing
- `npm test` (backend) *(passes: no tests defined)*
- `npm test` (frontend) *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678e4620c88328bdd1caf88bcfd639